### PR TITLE
Modified for Spark 1.1.0

### DIFF
--- a/src/build.sbt
+++ b/src/build.sbt
@@ -4,7 +4,7 @@ organization := "org.alitouka"
 
 version := "0.0.2"
 
-libraryDependencies += "org.apache.spark" % "spark-core_2.10" % "1.0.0" % "provided"
+libraryDependencies += "org.apache.spark" % "spark-core_2.10" % "1.1.0" % "provided"
 
 libraryDependencies += "org.scalatest" % "scalatest_2.10" % "2.1.3" % "test"
 

--- a/src/src/main/scala/org/alitouka/spark/dbscan/spatial/DistanceAnalyzer.scala
+++ b/src/src/main/scala/org/alitouka/spark/dbscan/spatial/DistanceAnalyzer.scala
@@ -36,7 +36,7 @@ private [dbscan] class DistanceAnalyzer (
       .map ( x => (x, 1L))
 
     val allPointCounts = closePointCounts.union (pointsWithoutNeighbors)
-    val partitionedAndSortedCounts = new ShuffledRDD [PointSortKey, Long, (PointSortKey, Long)] (
+    val partitionedAndSortedCounts = new ShuffledRDD [PointSortKey, Long, Long] (
       allPointCounts,
       new BoxPartitioner (data.boxes)
     ).mapPartitions (sortPartition, true)

--- a/src/src/main/scala/org/alitouka/spark/dbscan/spatial/rdd/PointsInAdjacentBoxesRDD.scala
+++ b/src/src/main/scala/org/alitouka/spark/dbscan/spatial/rdd/PointsInAdjacentBoxesRDD.scala
@@ -19,7 +19,7 @@ import org.alitouka.spark.dbscan.PairOfAdjacentBoxIds
  * @param adjacentBoxIdPairs A collection of distinct pairs of box IDs
  */
 private [dbscan] class PointsInAdjacentBoxesRDD (prev: RDD[(PairOfAdjacentBoxIds, Point)], val adjacentBoxIdPairs: Array[PairOfAdjacentBoxIds])
-  extends ShuffledRDD [PairOfAdjacentBoxIds, Point, (PairOfAdjacentBoxIds, Point)] (prev, new AdjacentBoxesPartitioner(adjacentBoxIdPairs))
+  extends ShuffledRDD [PairOfAdjacentBoxIds, Point, Point] (prev, new AdjacentBoxesPartitioner(adjacentBoxIdPairs))
 
 private [dbscan] object PointsInAdjacentBoxesRDD {
 

--- a/src/src/main/scala/org/alitouka/spark/dbscan/spatial/rdd/PointsPartitionedByBoxesRDD.scala
+++ b/src/src/main/scala/org/alitouka/spark/dbscan/spatial/rdd/PointsPartitionedByBoxesRDD.scala
@@ -13,7 +13,7 @@ import org.alitouka.spark.dbscan.util.PointIndexer
   * @param boundingBox
   */
 private [dbscan] class PointsPartitionedByBoxesRDD  (prev: RDD[(PointSortKey, Point)], val boxes: Iterable[Box], val boundingBox: Box)
-  extends ShuffledRDD [PointSortKey, Point, (PointSortKey, Point)] (prev, new BoxPartitioner(boxes))
+  extends ShuffledRDD [PointSortKey, Point, Point] (prev, new BoxPartitioner(boxes))
 
 object PointsPartitionedByBoxesRDD {
 


### PR DESCRIPTION
I'm not sure how you intend to support different versions of Spark but here's a small commit to support Spark 1.1.0 instead of the older 1.0.x versions. It works fine for me but I did not look too closely for issues!
## Commit msg

Due to a small change in ShuffledRDD's template parameters introduced in
Spark 1.1.0 the code became incompatible with Spark 1.1.0. This commit
simply ensures the correct type parameters are sent to the ShuffledRDD
and modifies the build.sbt dependency to Spark 1.1.0.
