### PR TITLE
Modified BoxCalculator.getNumberOfDimensions to use .first()

### DIFF
--- a/src/src/main/scala/org/alitouka/spark/dbscan/spatial/BoxCalculator.scala
+++ b/src/src/main/scala/org/alitouka/spark/dbscan/spatial/BoxCalculator.scala
@@ -44,7 +44,7 @@ private [dbscan] class BoxCalculator (val data: RawDataSet) {
 
 
   private [dbscan] def getNumberOfDimensions (ds: RawDataSet): Int = {
-    val pt = ds.take(1)(0)
+    val pt = ds.first()
     pt.coordinates.length
   }
 


### PR DESCRIPTION
Modified BoxCalculator.getNumberOfDimensions to use .first() instead of .take(1)(0).  This resolves an issue we were having when trying to train a DBSCAN model within a Java application.
