### PR TITLE
Passed the DbscanSettings object along in the partitioning process.

### DIFF
--- a/src/src/main/scala/org/alitouka/spark/dbscan/spatial/rdd/PointsPartitionedByBoxesRDD.scala
+++ b/src/src/main/scala/org/alitouka/spark/dbscan/spatial/rdd/PointsPartitionedByBoxesRDD.scala
@@ -32,7 +32,7 @@ object PointsPartitionedByBoxesRDD {
       rawData,
       broadcastBoxes,
       broadcastNumberOfDimensions,
-      DbscanSettings.getDefaultDistanceMeasure)
+      dbscanSettings.distanceMeasure)
 
     PointsPartitionedByBoxesRDD (pointsInBoxes, boxes, boundingBox)
   }


### PR DESCRIPTION
Passed the DbscanSettings object along in the partitioning process, which enables the use of a custom distance measure.