### PR TITLE
Spark version is raised to 2.2.1

### DIFF
--- a/src/assembly.sbt
+++ b/src/assembly.sbt
@@ -1,5 +1,0 @@
-import AssemblyKeys._ // put this at the top of the file
-
-assemblySettings
-
-// your assembly settings here

--- a/src/build.sbt
+++ b/src/build.sbt
@@ -4,16 +4,23 @@ organization := "org.alitouka"
 
 version := "0.0.4"
 
-libraryDependencies += "org.apache.spark" % "spark-core_2.10" % "1.1.0" % "provided"
+scalaVersion := "2.10.6"
 
-libraryDependencies += "org.scalatest" % "scalatest_2.10" % "2.1.3" % "test"
+resolvers ++= Seq(
+  "apache-snapshots" at "http://repository.apache.org/snapshots/"
+)
+
+libraryDependencies += "org.apache.spark" %% "spark-core" % "2.2.1" % "provided"
+
+libraryDependencies += "org.scalatest" % "scalatest_2.10" % "3.0.4" % Test
 
 libraryDependencies += "org.apache.commons" % "commons-math3" % "3.2"
 
-libraryDependencies += "com.github.scopt" %% "scopt" % "3.2.0"
+libraryDependencies += "com.github.scopt" %% "scopt" % "3.7.0"
 
-resolvers += "Akka Repository" at "http://repo.akka.io/releases/"
+assemblyMergeStrategy in assembly := {
+  case PathList("META-INF", xs @ _*) => MergeStrategy.discard
+  case x => MergeStrategy.first
+}
 
-resolvers += Resolver.sonatypeRepo("public")
-
-publishTo := Some(Resolver.file("file",  new File(Path.userHome.absolutePath+"/.m2/repository")))
+test in assembly := {}

--- a/src/project/build.properties
+++ b/src/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.16

--- a/src/project/plugins.sbt
+++ b/src/project/plugins.sbt
@@ -1,3 +1,1 @@
-logLevel := Level.Warn
-
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.11.2")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")

--- a/src/src/main/scala/org/alitouka/spark/dbscan/Dbscan.scala
+++ b/src/src/main/scala/org/alitouka/spark/dbscan/Dbscan.scala
@@ -4,7 +4,7 @@ import org.apache.spark.SparkContext._
 import org.apache.spark.rdd.RDD
 import org.apache.commons.math3.ml.distance.{EuclideanDistance, DistanceMeasure}
 import scala.reflect._
-import org.apache.spark.Logging
+import org.apache.spark.internal.Logging
 import org.alitouka.spark.dbscan.spatial.DistanceAnalyzer
 import org.alitouka.spark.dbscan.spatial.rdd.PartitioningSettings
 

--- a/src/src/main/scala/org/alitouka/spark/dbscan/DistributedDbscan.scala
+++ b/src/src/main/scala/org/alitouka/spark/dbscan/DistributedDbscan.scala
@@ -8,7 +8,7 @@ import org.alitouka.spark.dbscan.spatial.rdd.{PointsInAdjacentBoxesRDD, PointsPa
 import scala.Some
 import org.alitouka.spark.dbscan.util.commandLine.CommonArgs
 import org.alitouka.spark.dbscan.util.debug.DebugHelper
-import org.apache.spark.Logging
+import org.apache.spark.internal.Logging
 import scala.collection.immutable.HashMap
 
 /** Implementation of the DBSCAN algorithm which is capable of parallel processing of the input data.

--- a/src/src/main/scala/org/alitouka/spark/dbscan/spatial/DistanceAnalyzer.scala
+++ b/src/src/main/scala/org/alitouka/spark/dbscan/spatial/DistanceAnalyzer.scala
@@ -7,7 +7,7 @@ import org.apache.commons.math3.ml.distance.DistanceMeasure
 import org.alitouka.spark.dbscan._
 import scala.collection.mutable.ListBuffer
 import org.alitouka.spark.dbscan.util.debug.DebugHelper
-import org.apache.spark.Logging
+import org.apache.spark.internal.Logging
 import scala.collection.mutable
 
 

--- a/src/src/main/scala/org/alitouka/spark/dbscan/util/debug/Clock.scala
+++ b/src/src/main/scala/org/alitouka/spark/dbscan/util/debug/Clock.scala
@@ -1,6 +1,6 @@
 package org.alitouka.spark.dbscan.util.debug
 
-import org.apache.spark.Logging
+import org.apache.spark.internal.Logging
 
 private [dbscan] class Clock extends Logging {
   val startTime = System.currentTimeMillis()

--- a/src/src/test/scala/org/alitouka/spark/dbscan/SuiteBase.scala
+++ b/src/src/test/scala/org/alitouka/spark/dbscan/SuiteBase.scala
@@ -1,7 +1,8 @@
 package org.alitouka.spark.dbscan
 
 import org.scalatest.{FunSuite, BeforeAndAfterEach, Matchers, FlatSpec}
-import org.apache.spark.{SparkContext, Logging}
+import org.apache.spark.SparkContext
+import org.apache.spark.internal.Logging
 import org.alitouka.spark.dbscan.spatial.{PointSortKey, Point}
 
 class SuiteBase extends FunSuite with Matchers with BeforeAndAfterEach with Logging {


### PR DESCRIPTION
To change Spark version just set it in build.sbt. Also in earlier versions change `import org.apache.spark.internal.Logging` to `import org.apache.spark.Logging` where Logging is used. If required.